### PR TITLE
Fix Flaky Test

### DIFF
--- a/wopmars/tests/test_wopmars.py
+++ b/wopmars/tests/test_wopmars.py
@@ -199,6 +199,15 @@ class TestWopmars(TestCase):
         self.assertEqual(se.exception.code, 0)
 
     def test_dry_run(self):
+        cmd_line = ['python', '-D', self.__db_url, '-w', self.__example_def_file2_only_files, '-v']
+        (time_unix_ms, time_human) = get_current_time()
+        start = time_unix_ms
+        with self.assertRaises(SystemExit):
+            WopMars().run(cmd_line)
+        (time_unix_ms, time_human) = get_current_time()
+        end = time_unix_ms
+        runtime1 = (end - start)
+        PathManager.unlink('outdir/output_file1.txt')
         cmd_line = ["python", "--dry-run", "-D", self.__db_url, "-w", self.__example_def_file1, "-v", "-d",
                     self.test_path]
         with self.assertRaises(SystemExit) as se:

--- a/wopmars/tests/test_wopmars.py
+++ b/wopmars/tests/test_wopmars.py
@@ -199,14 +199,6 @@ class TestWopmars(TestCase):
         self.assertEqual(se.exception.code, 0)
 
     def test_dry_run(self):
-        cmd_line = ['python', '-D', self.__db_url, '-w', self.__example_def_file2_only_files, '-v']
-        (time_unix_ms, time_human) = get_current_time()
-        start = time_unix_ms
-        with self.assertRaises(SystemExit):
-            WopMars().run(cmd_line)
-        (time_unix_ms, time_human) = get_current_time()
-        end = time_unix_ms
-        runtime1 = (end - start)
         PathManager.unlink('outdir/output_file1.txt')
         cmd_line = ["python", "--dry-run", "-D", self.__db_url, "-w", self.__example_def_file1, "-v", "-d",
                     self.test_path]


### PR DESCRIPTION
<h2>What is the purpose of this PR</h2>

- This PR patches `wopmars/tests/test_wopmars.py::TestWopmars::test_dry_run` and prevents it from failing when it is run after `wopmars/tests/test_tool_wrapper_thread.py::TestToolWrapperThread::test_run`
- Test is flaky (non-deterministic) and fails due to some state set up by `wopmars/tests/test_tool_wrapper_thread.py::TestToolWrapperThread::test_run`, but the test passes when it is run by itself otherwise

---

<h2>Expected Result</h2> 

- Test `wopmars/tests/test_wopmars.py::TestWopmars::test_dry_run` should pass when run both by itself and after `wopmars/tests/test_tool_wrapper_thread.py::TestToolWrapperThread::test_run`

---
<h2>Actual Result</h2> 

- Test `wopmars/tests/test_wopmars.py::TestWopmars::test_dry_run`  fails when it is run after `wopmars/tests/test_tool_wrapper_thread.py::TestToolWrapperThread::test_run`
- Specifically, we get the following:
```
____________________________________________________________________________________________ TestWopmars.test_dry_run _____________________________________________________________________________________________

self = <wopmars.tests.test_wopmars.TestWopmars testMethod=test_dry_run>

    def test_dry_run(self):
        cmd_line = ["python", "--dry-run", "-D", self.__db_url, "-w", self.__example_def_file1, "-v", "-d",
                    self.test_path]
        with self.assertRaises(SystemExit) as se:
            WopMars().run(cmd_line)
        # The tests is that these files do not exist
>       self.assertFalse(os.path.exists(os.path.join(self.test_path, 'outdir/output_file1.txt')))
E       AssertionError: True is not false

/home/ar-vi/wopmars/wopmars/tests/test_wopmars.py:207: AssertionError
```
---

<h2>Reproduce the test failure</h2>

- Run `python3 -m pytest wopmars/tests/test_tool_wrapper_thread.py::TestToolWrapperThread::test_run wopmars/tests/test_wopmars.py::TestWopmars::test_dry_run` 

---
<h2>Why the Test Fails</h2> 

- The test fails because of some "pollution"/state that is set by `wopmars/tests/test_tool_wrapper_thread.py::TestToolWrapperThread::test_run` .  

---
<h2>Fix</h2>

- The changes in this pull request clean up the state caused by the test run prior and makes the test pass. 

---
